### PR TITLE
Replacement HOT bucket

### DIFF
--- a/master.json
+++ b/master.json
@@ -6,7 +6,7 @@
             "locations": [
                 {
                     "type": "s3",
-                    "bucket_name": "hotosm-oam"
+                    "bucket_name": "oin-hotosm"
                 }                
             ]
         }, 


### PR DESCRIPTION
The new bucket contains (almost) all imagery from the old bucket,
transcoded for dramatically reduced file sizes and TMS-ready.

Refs hotosm/oam-uploader-api#52

Depends on hotosm/oam-catalog#85, specifically https://github.com/hotosm/oam-catalog/pull/85/commits/77ad5db3ed8d5146f2c177885a55b32bbb8d799f