### PR TITLE
Revert "Replacement HOT bucket"

### DIFF
--- a/master.json
+++ b/master.json
@@ -6,7 +6,7 @@
             "locations": [
                 {
                     "type": "s3",
-                    "bucket_name": "oin-hotosm"
+                    "bucket_name": "hotosm-oam"
                 }                
             ]
         }, 


### PR DESCRIPTION
Reverts openimagerynetwork/oin-register#16. Current OAM Catalog worker process breaks with these slight changes to the metadata and catalog. 

Reverting this temporarily because https://github.com/hotosm/oam-catalog/pull/85 hasn't been tested on staging and pushed to the production catalog. 

cc @mojodna @lossyrob 