### PR TITLE
[READY] Adds HOTs new OIN bucket

### DIFF
--- a/master.json
+++ b/master.json
@@ -6,7 +6,7 @@
             "locations": [
                 {
                     "type": "s3",
-                    "bucket_name": "hotosm-oam"
+                    "bucket_name": "oin-hotosm"
                 }                
             ]
         }, 


### PR DESCRIPTION
Recreating PR for adding new AWS S3 bucket for HOT. Related to https://github.com/openimagerynetwork/oin-register/pull/16 and https://github.com/openimagerynetwork/oin-register/pull/17. 

> The new bucket contains (almost) all imagery from the old bucket, transcoded for dramatically reduced file sizes and TMS-ready.

This creates breaking changes if running v1.0 of the OAM-Catalog: https://github.com/hotosm/oam-catalog/releases/tag/v1.0.0. See https://github.com/hotosm/oam-catalog/pull/89 for latest changes that include handling the new bucket changes. 

To be merged after updates to catalog are merged: https://github.com/hotosm/oam-catalog/pull/89. 

 See https://github.com/hotosm/oam-uploader-api/issues/52 for discussion. 

cc @openimagerynetwork/oin 